### PR TITLE
fix(subscription-service): missed Export of Sequelize Component in Index file

### DIFF
--- a/services/subscription-service/src/index.ts
+++ b/services/subscription-service/src/index.ts
@@ -3,6 +3,7 @@
 // This software is released under the MIT License.
 // https://opensource.org/licenses/MIT
 export * from './component';
+export * from './sequelize-component';
 export * from './types';
 export * from './keys';
 export * from './repositories';

--- a/services/tenant-management-service/src/index.ts
+++ b/services/tenant-management-service/src/index.ts
@@ -3,6 +3,7 @@
 // This software is released under the MIT License.
 // https://opensource.org/licenses/MIT
 export * from './component';
+export * from './sequelize-component';
 export * from './types';
 export * from './keys';
 export * from './repositories';


### PR DESCRIPTION
## Description

This PR adds the missing export for the Sequelize component in the index.ts file. Without this export, users were unable to import and use the Sequelize component from the package

Fixes # (issue)

GH-82

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Intermediate change (work in progress)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

## Checklist:

- [ ] Performed a self-review of my own code
- [ ] npm test passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the style guide
- [ ] API Documentation in code was updated
- [ ] Any dependent changes have been merged and published in downstream modules
