### PR TITLE
fix(subscription-service): standardize repository usage

### DIFF
--- a/services/subscription-service/src/repositories/sequelize/billing-customer.repository.ts
+++ b/services/subscription-service/src/repositories/sequelize/billing-customer.repository.ts
@@ -9,13 +9,15 @@ import {AuthenticationBindings} from 'loopback4-authentication';
 import {BillingCustomer, Invoice} from '../../models';
 import {SubscriptionDbSourceName} from '../../types';
 import {InvoiceRepository} from './../invoice.repository';
-import {
-  SequelizeCrudRepository,
-  SequelizeDataSource,
-} from '@loopback/sequelize';
+import {SequelizeDataSource} from '@loopback/sequelize';
+import {SequelizeUserModifyCrudRepository} from '@sourceloop/core/sequelize';
 export class BillingCustomerRepository<
   T extends BillingCustomer = BillingCustomer,
-> extends SequelizeCrudRepository<T, typeof BillingCustomer.prototype.id, {}> {
+> extends SequelizeUserModifyCrudRepository<
+  T,
+  typeof BillingCustomer.prototype.id,
+  {}
+> {
   public readonly invoices: HasManyRepositoryFactory<
     Invoice,
     typeof BillingCustomer.prototype.id
@@ -33,7 +35,7 @@ export class BillingCustomerRepository<
       prototype: T;
     },
   ) {
-    super(billingCustomer, dataSource);
+    super(billingCustomer, dataSource, getCurrentUser);
     this.invoices = this.createHasManyRepositoryFactoryFor(
       'invoices',
       invoiceRepositoryGetter,

--- a/services/subscription-service/src/repositories/sequelize/billing-cycle.repository.ts
+++ b/services/subscription-service/src/repositories/sequelize/billing-cycle.repository.ts
@@ -4,13 +4,15 @@ import {IAuthUserWithPermissions} from '@sourceloop/core';
 import {AuthenticationBindings} from 'loopback4-authentication';
 import {Entity} from '@loopback/repository';
 import {SubscriptionDbSourceName} from '../../types';
-import {
-  SequelizeCrudRepository,
-  SequelizeDataSource,
-} from '@loopback/sequelize';
+import {SequelizeDataSource} from '@loopback/sequelize';
+import {SequelizeUserModifyCrudRepository} from '@sourceloop/core/sequelize';
 export class BillingCycleRepository<
   T extends BillingCycle = BillingCycle,
-> extends SequelizeCrudRepository<T, typeof BillingCycle.prototype.id, {}> {
+> extends SequelizeUserModifyCrudRepository<
+  T,
+  typeof BillingCycle.prototype.id,
+  {}
+> {
   constructor(
     @inject(`datasources.${SubscriptionDbSourceName}`)
     dataSource: SequelizeDataSource,
@@ -19,6 +21,6 @@ export class BillingCycleRepository<
     @inject('models.BillingCycle')
     private readonly billingCycle: typeof Entity & {prototype: T},
   ) {
-    super(billingCycle, dataSource);
+    super(billingCycle, dataSource, getCurrentUser);
   }
 }

--- a/services/subscription-service/src/repositories/sequelize/invoice.repository.ts
+++ b/services/subscription-service/src/repositories/sequelize/invoice.repository.ts
@@ -4,13 +4,15 @@ import {IAuthUserWithPermissions} from '@sourceloop/core';
 import {AuthenticationBindings} from 'loopback4-authentication';
 import {Invoice} from '../../models';
 import {SubscriptionDbSourceName} from '../../types';
-import {
-  SequelizeCrudRepository,
-  SequelizeDataSource,
-} from '@loopback/sequelize';
+import {SequelizeDataSource} from '@loopback/sequelize';
+import {SequelizeUserModifyCrudRepository} from '@sourceloop/core/sequelize';
 export class InvoiceRepository<
   T extends Invoice = Invoice,
-> extends SequelizeCrudRepository<T, typeof Invoice.prototype.id, {}> {
+> extends SequelizeUserModifyCrudRepository<
+  T,
+  typeof Invoice.prototype.id,
+  {}
+> {
   constructor(
     @inject(`datasources.${SubscriptionDbSourceName}`)
     dataSource: SequelizeDataSource,
@@ -19,6 +21,6 @@ export class InvoiceRepository<
     @inject('models.Invoice')
     private readonly invoice: typeof Entity & {prototype: T},
   ) {
-    super(invoice, dataSource);
+    super(invoice, dataSource, getCurrentUser);
   }
 }

--- a/services/subscription-service/src/repositories/sequelize/plan-sizes.repository.ts
+++ b/services/subscription-service/src/repositories/sequelize/plan-sizes.repository.ts
@@ -4,13 +4,11 @@ import {IAuthUserWithPermissions} from '@sourceloop/core';
 import {AuthenticationBindings} from 'loopback4-authentication';
 import {Entity} from '@loopback/repository';
 import {SubscriptionDbSourceName} from '../../types';
-import {
-  SequelizeCrudRepository,
-  SequelizeDataSource,
-} from '@loopback/sequelize';
+import {SequelizeDataSource} from '@loopback/sequelize';
+import {SequelizeUserModifyCrudRepository} from '@sourceloop/core/sequelize';
 export class PlanSizesRepository<
   T extends PlanSizes = PlanSizes,
-> extends SequelizeCrudRepository<
+> extends SequelizeUserModifyCrudRepository<
   T,
   typeof PlanSizes.prototype.id,
   PlanSizesRelations
@@ -23,6 +21,6 @@ export class PlanSizesRepository<
     @inject('models.PlanSizes')
     private readonly planSizes: typeof Entity & {prototype: T},
   ) {
-    super(planSizes, dataSource);
+    super(planSizes, dataSource, getCurrentUser);
   }
 }

--- a/services/subscription-service/src/repositories/sequelize/plan.repository.ts
+++ b/services/subscription-service/src/repositories/sequelize/plan.repository.ts
@@ -6,13 +6,15 @@ import {repository, BelongsToAccessor, Entity} from '@loopback/repository';
 import {BillingCycleRepository} from './billing-cycle.repository';
 import {CurrencyRepository} from './currency.repository';
 import {SubscriptionDbSourceName} from '../../types';
-import {
-  SequelizeCrudRepository,
-  SequelizeDataSource,
-} from '@loopback/sequelize';
+import {SequelizeDataSource} from '@loopback/sequelize';
+import {SequelizeUserModifyCrudRepository} from '@sourceloop/core/sequelize';
 export class PlanRepository<
   T extends Plan = Plan,
-> extends SequelizeCrudRepository<T, typeof Plan.prototype.id, PlanRelations> {
+> extends SequelizeUserModifyCrudRepository<
+  T,
+  typeof Plan.prototype.id,
+  PlanRelations
+> {
   public readonly billingCycle: BelongsToAccessor<
     BillingCycle,
     typeof Plan.prototype.id
@@ -35,7 +37,7 @@ export class PlanRepository<
     @inject('models.Plan')
     private readonly plan: typeof Entity & {prototype: T},
   ) {
-    super(plan, dataSource);
+    super(plan, dataSource, getCurrentUser);
     this.currency = this.createBelongsToAccessorFor(
       'currency',
       currencyRepositoryGetter,

--- a/services/subscription-service/src/repositories/sequelize/resource.repository.ts
+++ b/services/subscription-service/src/repositories/sequelize/resource.repository.ts
@@ -4,13 +4,11 @@ import {IAuthUserWithPermissions} from '@sourceloop/core';
 import {AuthenticationBindings} from 'loopback4-authentication';
 import {Entity} from '@loopback/repository';
 import {SubscriptionDbSourceName} from '../../types';
-import {
-  SequelizeCrudRepository,
-  SequelizeDataSource,
-} from '@loopback/sequelize';
+import {SequelizeDataSource} from '@loopback/sequelize';
+import {SequelizeUserModifyCrudRepository} from '@sourceloop/core/sequelize';
 export class ResourceRepository<
   T extends Resource = Resource,
-> extends SequelizeCrudRepository<
+> extends SequelizeUserModifyCrudRepository<
   T,
   typeof Resource.prototype.id,
   ResourceRelations
@@ -23,6 +21,6 @@ export class ResourceRepository<
     @inject('models.Resource')
     private readonly resource: typeof Entity & {prototype: T},
   ) {
-    super(resource, dataSource);
+    super(resource, dataSource, getCurrentUser);
   }
 }

--- a/services/subscription-service/src/repositories/sequelize/service.repository.ts
+++ b/services/subscription-service/src/repositories/sequelize/service.repository.ts
@@ -4,13 +4,11 @@ import {IAuthUserWithPermissions} from '@sourceloop/core';
 import {AuthenticationBindings} from 'loopback4-authentication';
 import {Entity} from '@loopback/repository';
 import {SubscriptionDbSourceName} from '../../types';
-import {
-  SequelizeCrudRepository,
-  SequelizeDataSource,
-} from '@loopback/sequelize';
+import {SequelizeDataSource} from '@loopback/sequelize';
+import {SequelizeUserModifyCrudRepository} from '@sourceloop/core/sequelize';
 export class ServiceRepository<
   T extends Service = Service,
-> extends SequelizeCrudRepository<
+> extends SequelizeUserModifyCrudRepository<
   T,
   typeof Service.prototype.id,
   ServiceRelations
@@ -23,6 +21,6 @@ export class ServiceRepository<
     @inject('models.Service')
     private readonly service: typeof Entity & {prototype: T},
   ) {
-    super(service, dataSource);
+    super(service, dataSource, getCurrentUser);
   }
 }

--- a/services/subscription-service/src/repositories/sequelize/subscription.repository.ts
+++ b/services/subscription-service/src/repositories/sequelize/subscription.repository.ts
@@ -6,13 +6,11 @@ import {AuthenticationBindings} from 'loopback4-authentication';
 import {IAuthUserWithPermissions} from '@sourceloop/core';
 import {SubscriptionDbSourceName} from '../../types';
 import {InvoiceRepository} from './invoice.repository';
-import {
-  SequelizeCrudRepository,
-  SequelizeDataSource,
-} from '@loopback/sequelize';
+import {SequelizeDataSource} from '@loopback/sequelize';
+import {SequelizeUserModifyCrudRepository} from '@sourceloop/core/sequelize';
 export class SubscriptionRepository<
   T extends Subscription = Subscription,
-> extends SequelizeCrudRepository<
+> extends SequelizeUserModifyCrudRepository<
   T,
   typeof Subscription.prototype.id,
   SubscriptionRelations
@@ -39,7 +37,7 @@ export class SubscriptionRepository<
     @inject('models.Subscription')
     private readonly subscription: typeof Entity & {prototype: T},
   ) {
-    super(subscription, dataSource);
+    super(subscription, dataSource, getCurrentUser);
     this.invoice = this.createBelongsToAccessorFor(
       'invoice',
       invoiceRepositoryGetter,

--- a/services/tenant-management-service/src/repositories/sequelize/address.repository.ts
+++ b/services/tenant-management-service/src/repositories/sequelize/address.repository.ts
@@ -1,17 +1,19 @@
 import {Getter, inject} from '@loopback/core';
 import {BelongsToAccessor, Entity} from '@loopback/repository';
 import {IAuthUserWithPermissions} from '@sourceloop/core';
-import {
-  SequelizeCrudRepository,
-  SequelizeDataSource,
-} from '@loopback/sequelize';
+import {SequelizeDataSource} from '@loopback/sequelize';
+import {SequelizeUserModifyCrudRepository} from '@sourceloop/core/sequelize';
 import {Address, Tenant} from '../../models';
 import {SYSTEM_USER} from '../../keys';
 import {TenantManagementDbSourceName} from '../../types';
 
 export class AddressRepository<
   T extends Address = Address,
-> extends SequelizeCrudRepository<T, typeof Address.prototype.id, {}> {
+> extends SequelizeUserModifyCrudRepository<
+  T,
+  typeof Address.prototype.id,
+  {}
+> {
   public readonly tenant: BelongsToAccessor<
     Tenant,
     typeof Address.prototype.id
@@ -25,6 +27,6 @@ export class AddressRepository<
     @inject('models.Address')
     private readonly address: typeof Entity & {prototype: T},
   ) {
-    super(address, dataSource);
+    super(address, dataSource, getCurrentUser);
   }
 }

--- a/services/tenant-management-service/src/repositories/sequelize/contact.repository.ts
+++ b/services/tenant-management-service/src/repositories/sequelize/contact.repository.ts
@@ -2,17 +2,19 @@ import {Getter, inject} from '@loopback/core';
 import {BelongsToAccessor, Entity, repository} from '@loopback/repository';
 import {IAuthUserWithPermissions} from '@sourceloop/core';
 import {AuthenticationBindings} from 'loopback4-authentication';
-import {
-  SequelizeCrudRepository,
-  SequelizeDataSource,
-} from '@loopback/sequelize';
+import {SequelizeDataSource} from '@loopback/sequelize';
+import {SequelizeUserModifyCrudRepository} from '@sourceloop/core/sequelize';
 import {Contact, Tenant} from '../../models';
 import {TenantRepository} from './tenant.repository';
 import {TenantManagementDbSourceName} from '../../types';
 
 export class ContactRepository<
   T extends Contact = Contact,
-> extends SequelizeCrudRepository<T, typeof Contact.prototype.id, {}> {
+> extends SequelizeUserModifyCrudRepository<
+  T,
+  typeof Contact.prototype.id,
+  {}
+> {
   public readonly tenant: BelongsToAccessor<
     Tenant,
     typeof Contact.prototype.id
@@ -28,7 +30,7 @@ export class ContactRepository<
     @inject('models.Contact')
     private readonly contact: typeof Entity & {prototype: T},
   ) {
-    super(contact, dataSource);
+    super(contact, dataSource, getCurrentUser);
     this.tenant = this.createBelongsToAccessorFor(
       'tenant',
       tenantRepositoryGetter,

--- a/services/tenant-management-service/src/repositories/sequelize/invoice.repository.ts
+++ b/services/tenant-management-service/src/repositories/sequelize/invoice.repository.ts
@@ -2,17 +2,15 @@ import {Getter, inject} from '@loopback/core';
 import {BelongsToAccessor, Entity, repository} from '@loopback/repository';
 import {IAuthUserWithPermissions} from '@sourceloop/core';
 import {AuthenticationBindings} from 'loopback4-authentication';
-import {
-  SequelizeCrudRepository,
-  SequelizeDataSource,
-} from '@loopback/sequelize';
+import {SequelizeDataSource} from '@loopback/sequelize';
+import {SequelizeUserModifyCrudRepository} from '@sourceloop/core/sequelize';
 import {Invoice, InvoiceRelations, Tenant} from '../../models';
 import {TenantRepository} from './tenant.repository';
 import {TenantManagementDbSourceName} from '../../types';
 
 export class InvoiceRepository<
   T extends Invoice = Invoice,
-> extends SequelizeCrudRepository<
+> extends SequelizeUserModifyCrudRepository<
   T,
   typeof Invoice.prototype.id,
   InvoiceRelations
@@ -32,7 +30,7 @@ export class InvoiceRepository<
     @inject('models.Invoice')
     private readonly invoice: typeof Entity & {prototype: T},
   ) {
-    super(invoice, dataSource);
+    super(invoice, dataSource, getCurrentUser);
     this.tenant = this.createBelongsToAccessorFor(
       'tenant',
       tenantRepositoryGetter,

--- a/services/tenant-management-service/src/repositories/sequelize/lead.repository.ts
+++ b/services/tenant-management-service/src/repositories/sequelize/lead.repository.ts
@@ -7,10 +7,8 @@ import {
   HasOneRepositoryFactory,
   repository,
 } from '@loopback/repository';
-import {
-  SequelizeCrudRepository,
-  SequelizeDataSource,
-} from '@loopback/sequelize';
+import {SequelizeDataSource} from '@loopback/sequelize';
+import {SequelizeUserModifyCrudRepository} from '@sourceloop/core/sequelize';
 import {SYSTEM_USER} from '../../keys';
 import {Address, Lead, LeadRelations, Tenant} from '../../models';
 import {TenantRepository} from './tenant.repository';
@@ -19,7 +17,11 @@ import {TenantManagementDbSourceName} from '../../types';
 
 export class LeadRepository<
   T extends Lead = Lead,
-> extends SequelizeCrudRepository<T, typeof Lead.prototype.id, LeadRelations> {
+> extends SequelizeUserModifyCrudRepository<
+  T,
+  typeof Lead.prototype.id,
+  LeadRelations
+> {
   public readonly tenant: HasOneRepositoryFactory<
     Tenant,
     typeof Tenant.prototype.id
@@ -42,7 +44,7 @@ export class LeadRepository<
     @inject('models.Lead')
     private readonly lead: typeof Entity & {prototype: T},
   ) {
-    super(lead, dataSource);
+    super(lead, dataSource, getCurrentUser);
     this.tenant = this.createHasOneRepositoryFactoryFor(
       'tenant',
       tenantRepositoryGetter,

--- a/services/tenant-management-service/src/repositories/sequelize/resource.repository.ts
+++ b/services/tenant-management-service/src/repositories/sequelize/resource.repository.ts
@@ -2,17 +2,15 @@ import {Getter, inject} from '@loopback/core';
 import {BelongsToAccessor, Entity, repository} from '@loopback/repository';
 import {IAuthUserWithPermissions} from '@sourceloop/core';
 import {AuthenticationBindings} from 'loopback4-authentication';
-import {
-  SequelizeCrudRepository,
-  SequelizeDataSource,
-} from '@loopback/sequelize';
+import {SequelizeDataSource} from '@loopback/sequelize';
+import {SequelizeUserModifyCrudRepository} from '@sourceloop/core/sequelize';
 import {Resource, ResourceRelations, Tenant} from '../../models';
 import {TenantRepository} from './tenant.repository';
 import {ResourceData, TenantManagementDbSourceName} from '../../types';
 
 export class ResourceRepository<
   T extends ResourceData['metadata'] = ResourceData['metadata'],
-> extends SequelizeCrudRepository<
+> extends SequelizeUserModifyCrudRepository<
   Resource<T>,
   typeof Resource.prototype.id,
   ResourceRelations
@@ -32,7 +30,7 @@ export class ResourceRepository<
     @inject('models.Resource')
     private readonly resource: typeof Entity & {prototype: Resource<T>},
   ) {
-    super(resource, dataSource);
+    super(resource, dataSource, getCurrentUser);
     this.tenant = this.createBelongsToAccessorFor(
       'tenant',
       tenantRepositoryGetter,

--- a/services/tenant-management-service/src/repositories/sequelize/tenant-mgmt-config.repository.ts
+++ b/services/tenant-management-service/src/repositories/sequelize/tenant-mgmt-config.repository.ts
@@ -5,14 +5,15 @@ import {IAuthUserWithPermissions} from '@sourceloop/core';
 import {SYSTEM_USER} from '../../keys';
 import {TenantManagementDbSourceName} from '../../types';
 import {TenantRepository} from './tenant.repository';
-import {
-  SequelizeCrudRepository,
-  SequelizeDataSource,
-} from '@loopback/sequelize';
-
+import {SequelizeDataSource} from '@loopback/sequelize';
+import {SequelizeUserModifyCrudRepository} from '@sourceloop/core/sequelize';
 export class TenantMgmtConfigRepository<
   T extends TenantMgmtConfig = TenantMgmtConfig,
-> extends SequelizeCrudRepository<T, typeof TenantMgmtConfig.prototype.id, {}> {
+> extends SequelizeUserModifyCrudRepository<
+  T,
+  typeof TenantMgmtConfig.prototype.id,
+  {}
+> {
   public readonly tenant: BelongsToAccessor<
     Tenant,
     typeof TenantMgmtConfig.prototype.id
@@ -30,7 +31,7 @@ export class TenantMgmtConfigRepository<
       prototype: T;
     },
   ) {
-    super(tenantMgmtConfig, dataSource);
+    super(tenantMgmtConfig, dataSource, getCurrentUser);
     this.tenant = this.createBelongsToAccessorFor(
       'tenant',
       tenantRepositoryGetter,

--- a/services/tenant-management-service/src/repositories/sequelize/tenant.repository.ts
+++ b/services/tenant-management-service/src/repositories/sequelize/tenant.repository.ts
@@ -7,10 +7,8 @@ import {
 } from '@loopback/repository';
 import {IAuthUserWithPermissions} from '@sourceloop/core';
 import {AuthenticationBindings} from 'loopback4-authentication';
-import {
-  SequelizeCrudRepository,
-  SequelizeDataSource,
-} from '@loopback/sequelize';
+import {SequelizeDataSource} from '@loopback/sequelize';
+import {SequelizeUserModifyCrudRepository} from '@sourceloop/core/sequelize';
 import {
   Address,
   Contact,
@@ -27,7 +25,7 @@ import {TenantManagementDbSourceName} from '../../types';
 
 export class TenantRepository<
   T extends Tenant = Tenant,
-> extends SequelizeCrudRepository<
+> extends SequelizeUserModifyCrudRepository<
   T,
   typeof Tenant.prototype.id,
   TenantRelations
@@ -65,7 +63,7 @@ export class TenantRepository<
     @inject('models.Tenant')
     private readonly tenant: typeof Entity & {prototype: T},
   ) {
-    super(tenant, dataSource);
+    super(tenant, dataSource, getCurrentUser);
     this.lead = this.createBelongsToAccessorFor('lead', leadRepositoryGetter);
     this.registerInclusionResolver('lead', this.lead.inclusionResolver);
     this.contacts = this.createHasManyRepositoryFactoryFor(


### PR DESCRIPTION
## Description

In Sequelize repositories ,extends class from 'SequelizeUserModifyCrudRepository' instead of 'SequelizeCrudRepository' whose base model extends 'UserModifiableEntity'

Fixes # (issue)

GH-84

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Intermediate change (work in progress)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

## Checklist:

- [ ] Performed a self-review of my own code
- [ ] npm test passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the style guide
- [ ] API Documentation in code was updated
- [ ] Any dependent changes have been merged and published in downstream modules
