### PR TITLE
fix(all-services): changes to manually update major version for first time

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ name: Release [Manual]
 on: workflow_dispatch
 permissions:
   contents: write
+  id-token: write
 jobs:
   Release:
     runs-on: ubuntu-latest
@@ -27,15 +28,15 @@ jobs:
           GITHUB_PAT: ${{ secrets.RELEASE_COMMIT_GH_PAT }}
           CONFIG_USERNAME: ${{ vars.RELEASE_COMMIT_USERNAME }}
           CONFIG_EMAIL: ${{ vars.RELEASE_COMMIT_EMAIL }}
-      - name: Authenticate with Registry
-        run: |
-          echo "@${NPM_USERNAME}:registry=https://registry.npmjs.org/" > .npmrc
-          echo "registry=https://registry.npmjs.org/" >> .npmrc
-          echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> .npmrc
-          npm whoami
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-          NPM_USERNAME: ${{ vars.NPM_USERNAME }}
+      # - name: Authenticate with Registry
+      #   run: |
+      #     echo "@${NPM_USERNAME}:registry=https://registry.npmjs.org/" > .npmrc
+      #     echo "registry=https://registry.npmjs.org/" >> .npmrc
+      #     echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> .npmrc
+      #     npm whoami
+      #   env:
+      #     NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+      #     NPM_USERNAME: ${{ vars.NPM_USERNAME }}
 
       - name: Bootstrap
         run: npm ci
@@ -51,10 +52,13 @@ jobs:
         run: git stash
       - name: Bump Versions
         # "HUSKY=0" disables pre-commit-msg check (Needed in order to allow lerna perform the release commit)
-        run: HUSKY=0 npx lerna version --yes --ci --conventional-commits
+        # run: HUSKY=0 npx lerna version --yes --ci --conventional-commits
+        # Bumping major version for release will remove once released
+        run: HUSKY=0 npx lerna version major --yes --ci --conventional-commits 
       - name: Publish to NPM 🚀
         # To always compare changes from registry
         # using `from-package` compares version in local package.json with registry and publish it if required.
-        run: npx lerna publish from-package --yes
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        # using `--provenance` to generate provenance file for each package published.
+        run: npx lerna publish from-package --yes --provenance
+        # env:
+        #   NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/packages/custom-sf-changelog/conventional-recommended-bump.js
+++ b/packages/custom-sf-changelog/conventional-recommended-bump.js
@@ -6,39 +6,21 @@ module.exports = {
   parserOpts,
 
   whatBump: commits => {
-    console.log('=== WHATBUMP DEBUG ===');
-    console.log('Total commits to analyze:', commits.length);
-
     let level = 2;
     let breakings = 0;
     let features = 0;
 
-    commits.forEach((commit, index) => {
-      console.log(`\nCommit ${index + 1}:`, commit.header);
-      console.log('  Type:', commit.type);
-      console.log(
-        '  Notes length:',
-        commit.notes ? commit.notes.length : 'undefined',
-      );
-      console.log('  Notes:', JSON.stringify(commit.notes, null, 2));
-
-      if (commit.notes && commit.notes.length > 0) {
+    commits.forEach(commit => {
+      if (commit.notes.length > 0) {
         breakings += commit.notes.length;
         level = 0;
-        console.log('  -> BREAKING CHANGE DETECTED');
       } else if (commit.type === 'feat') {
         features += 1;
         if (level === 2) {
           level = 1;
         }
-        console.log('  -> Feature detected');
       }
     });
-
-    console.log('\n=== FINAL RESULT ===');
-    console.log('Level:', level, '(0=major, 1=minor, 2=patch)');
-    console.log('Breaking changes:', breakings);
-    console.log('Features:', features);
 
     return {
       level: level,

--- a/services/orchestrator-service/package.json
+++ b/services/orchestrator-service/package.json
@@ -1,109 +1,110 @@
 {
-    "name": "@sourceloop/ctrl-plane-orchestrator-service",
-    "version": "0.2.0",
-    "description": "ARC SaaS Orchestrator service.",
-    "keywords": [
-        "loopback-microservice",
-        "loopback",
-        "saas",
-        "tenant",
-        "tenant-management",
-        "tenant-service",
-        "control-plane",
-        "multi-tenant",
-        "multi-tenant-saas",
-        "multi-tenancy"
-    ],
-    "main": "dist/index.js",
-    "types": "dist/index.d.ts",
-    "engines": {
-        "node": ">=20"
-    },
-    "scripts": {
-        "build": "lb-tsc",
-        "build:watch": "lb-tsc --watch",
-        "lint": "npm run eslint && npm run prettier:check",
-        "lint:fix": "npm run eslint:fix && npm run prettier:fix",
-        "prettier:cli": "prettier \"**/*.ts\" \"**/*.js\"",
-        "prettier:check": "npm run prettier:cli -- -l",
-        "prettier:fix": "npm run prettier:cli -- --write",
-        "eslint": "eslint --report-unused-disable-directives .",
-        "eslint:fix": "npm run eslint -- --fix",
-        "pretest": "npm run rebuild",
-        "posttest": "npm run lint",
-        "test": "lb-mocha --allow-console-logs \"dist/__tests__\"",
-        "test:dev": "lb-mocha --allow-console-logs dist/__tests__/**/*.js",
-        "symlink-resolver": "symlink-resolver",
-        "resolve-links": "npm run symlink-resolver build ./node_modules/@local",
-        "premigrate": "npm run build",
-        "migrate": "node ./dist/migrate",
-        "preopenapi-spec": "npm run build",
-        "openapi-spec": "node ./dist/openapi-spec",
-        "prestart": "npm run clean && npm run openapi-spec",
-        "start": "node -r source-map-support/register .",
-        "dev": "nodemon --watch src -e ts --exec \"npm run start\"",
-        "clean": "lb-clean dist *.tsbuildinfo .eslintcache",
-        "rebuild": "npm run clean && npm run build",
-        "coverage": "nyc npm run test"
-    },
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/sourcefuse/arc-saas"
-    },
-    "author": "SourceFuse",
-    "license": "MIT",
-    "files": [
-        "README.md",
-        "dist",
-        "src",
-        "!*/__tests__"
-    ],
-    "dependencies": {
-        "tslib": "^2.6.2"
-    },
-    "peerDependencies": {
-        "@loopback/core": "^7.0.3"
-    },
-    "devDependencies": {
-        "@istanbuljs/nyc-config-typescript": "^1.0.2",
-        "@loopback/boot": "^8.0.4",
-        "@loopback/build": "^12.0.3",
-        "@loopback/context": "^8.0.3",
-        "@loopback/core": "^7.0.3",
-        "@loopback/eslint-config": "^16.0.1",
-        "@loopback/logging": "^0.13.5",
-        "@loopback/openapi-v3": "^11.0.4",
-        "@loopback/repository": "^8.0.3",
-        "@loopback/rest": "^15.0.4",
-        "@loopback/rest-explorer": "^8.0.4",
-        "@loopback/service-proxy": "^8.0.3",
-        "@loopback/testlab": "^8.0.3",
-        "@types/aws-lambda": "^8.10.110",
-        "@types/i18n": "^0.13.6",
-        "@types/node": "^20.12.7",
-        "@vendia/serverless-express": "^4.10.1",
-        "dotenv": "^16.4.5",
-        "dotenv-extended": "^2.9.0",
-        "nodemon": "^2.0.21",
-        "nyc": "^15.1.0",
-        "source-map-support": "^0.5.21",
-        "swagger-stats": "^0.99.5",
-        "symlink-resolver": "0.2.1",
-        "typescript": "^5.4.5"
-    },
-    "publishConfig": {
-        "registry": "https://registry.npmjs.org/",
-        "access": "public"
-    },
-    "typedoc": {
-        "config": {
-            "entryPoints": [
-                "src/index.ts"
-            ],
-            "out": "services/tenant-management-service",
-            "plugin": [
-                "typedoc-plugin-markdown"
-            ]
-        }
+  "name": "@sourceloop/ctrl-plane-orchestrator-service",
+  "version": "0.2.0",
+  "description": "ARC SaaS Orchestrator service",
+  "keywords": [
+    "loopback-microservice",
+    "loopback",
+    "saas",
+    "tenant",
+    "tenant-management",
+    "tenant-service",
+    "control-plane",
+    "multi-tenant",
+    "multi-tenant-saas",
+    "multi-tenancy"
+  ],
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "engines": {
+    "node": ">=20"
+  },
+  "scripts": {
+    "build": "lb-tsc",
+    "build:watch": "lb-tsc --watch",
+    "lint": "npm run eslint && npm run prettier:check",
+    "lint:fix": "npm run eslint:fix && npm run prettier:fix",
+    "prettier:cli": "prettier \"**/*.ts\" \"**/*.js\"",
+    "prettier:check": "npm run prettier:cli -- -l",
+    "prettier:fix": "npm run prettier:cli -- --write",
+    "eslint": "eslint --report-unused-disable-directives .",
+    "eslint:fix": "npm run eslint -- --fix",
+    "pretest": "npm run rebuild",
+    "posttest": "npm run lint",
+    "test": "lb-mocha --allow-console-logs \"dist/__tests__\"",
+    "test:dev": "lb-mocha --allow-console-logs dist/__tests__/**/*.js",
+    "symlink-resolver": "symlink-resolver",
+    "resolve-links": "npm run symlink-resolver build ./node_modules/@local",
+    "premigrate": "npm run build",
+    "migrate": "node ./dist/migrate",
+    "preopenapi-spec": "npm run build",
+    "openapi-spec": "node ./dist/openapi-spec",
+    "prestart": "npm run clean && npm run openapi-spec",
+    "start": "node -r source-map-support/register .",
+    "dev": "nodemon --watch src -e ts --exec \"npm run start\"",
+    "clean": "lb-clean dist *.tsbuildinfo .eslintcache",
+    "rebuild": "npm run clean && npm run build",
+    "coverage": "nyc npm run test"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/sourcefuse/arc-saas"
+  },
+  "author": "SourceFuse",
+  "license": "MIT",
+  "files": [
+    "README.md",
+    "dist",
+    "src",
+    "!*/__tests__"
+  ],
+  "dependencies": {
+    "tslib": "^2.6.2"
+  },
+  "peerDependencies": {
+    "@loopback/core": "^7.0.3"
+  },
+  "devDependencies": {
+    "@istanbuljs/nyc-config-typescript": "^1.0.2",
+    "@loopback/boot": "^8.0.4",
+    "@loopback/build": "^12.0.3",
+    "@loopback/context": "^8.0.3",
+    "@loopback/core": "^7.0.3",
+    "@loopback/eslint-config": "^16.0.1",
+    "@loopback/logging": "^0.13.5",
+    "@loopback/openapi-v3": "^11.0.4",
+    "@loopback/repository": "^8.0.3",
+    "@loopback/rest": "^15.0.4",
+    "@loopback/rest-explorer": "^8.0.4",
+    "@loopback/service-proxy": "^8.0.3",
+    "@loopback/testlab": "^8.0.3",
+    "@types/aws-lambda": "^8.10.110",
+    "@types/i18n": "^0.13.6",
+    "@types/node": "^20.12.7",
+    "@vendia/serverless-express": "^4.10.1",
+    "dotenv": "^16.4.5",
+    "dotenv-extended": "^2.9.0",
+    "nodemon": "^2.0.21",
+    "nyc": "^15.1.0",
+    "source-map-support": "^0.5.21",
+    "swagger-stats": "^0.99.5",
+    "symlink-resolver": "0.2.1",
+    "typescript": "^5.4.5"
+  },
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/",
+    "access": "public",
+    "provenance": true
+  },
+  "typedoc": {
+    "config": {
+      "entryPoints": [
+        "src/index.ts"
+      ],
+      "out": "services/tenant-management-service",
+      "plugin": [
+        "typedoc-plugin-markdown"
+      ]
     }
+  }
 }

--- a/services/subscription-service/package.json
+++ b/services/subscription-service/package.json
@@ -1,128 +1,129 @@
 {
-    "name": "@sourceloop/ctrl-plane-subscription-service",
-    "version": "0.5.0",
-    "description": "Subscription management microservice for SaaS control plane.",
-    "keywords": [
-        "loopback-microservice",
-        "loopback",
-        "saas",
-        "subscription",
-        "subscription-management",
-        "subscription-service",
-        "control-plane",
-        "multi-tenant",
-        "multi-tenant-saas",
-        "multi-tenancy"
-    ],
-    "main": "dist/index.js",
-    "types": "dist/index.d.ts",
-    "engines": {
-        "node": ">=20"
-    },
-    "scripts": {
-        "build": "lb-tsc",
-        "build:watch": "lb-tsc --watch",
-        "lint": "npm run eslint && npm run prettier:check",
-        "lint:fix": "npm run eslint:fix && npm run prettier:fix",
-        "prettier:cli": "prettier \"**/*.ts\" \"**/*.js\"",
-        "prettier:check": "npm run prettier:cli -- -l",
-        "prettier:fix": "npm run prettier:cli -- --write",
-        "eslint": "eslint --report-unused-disable-directives .",
-        "eslint:fix": "npm run eslint -- --fix",
-        "pretest": "npm run rebuild",
-        "test": "lb-mocha --allow-console-logs \"dist/__tests__\"",
-        "test:dev": "lb-mocha --allow-console-logs dist/__tests__/**/*.js",
-        "docker:build": "DOCKER_BUILDKIT=1 sudo docker build --build-arg NR_ENABLED=$NR_ENABLED_VALUE --build-arg SERVICE_NAME=subscription-service --build-arg FROM_FOLDER=services  -t $IMAGE_REPO_NAME/$npm_package_name:$npm_package_version ../../. -f ./Dockerfile",
-        "docker:run": "docker run -p 3000:3000 -d subscription-service",
-        "symlink-resolver": "symlink-resolver",
-        "resolve-links": "npm run symlink-resolver build ./node_modules/@local",
-        "premigrate": "npm run build",
-        "migrate": "node ./dist/migrate",
-        "preopenapi-spec": "npm run build",
-        "openapi-spec": "node ./dist/openapi-spec",
-        "prestart": "npm run clean && npm run openapi-spec",
-        "start": "node -r ./dist/opentelemetry-registry.js -r source-map-support/register .",
-        "dev": "nodemon --watch src -e ts --exec \"npm run start\"",
-        "clean": "lb-clean dist *.tsbuildinfo .eslintcache",
-        "rebuild": "npm run clean && npm run build",
-        "docker:push": "sudo docker push $IMAGE_REPO_NAME/$npm_package_name:$npm_package_version",
-        "docker:build:dev": "DOCKER_BUILDKIT=1 sudo docker build --build-arg NR_ENABLED=$NR_ENABLED_VALUE -t $REPOSITORY_URI:$npm_package_name .",
-        "docker:push:dev": "docker push $REPOSITORY_URI:undefined",
-        "coverage": "nyc npm run test"
-    },
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/sourcefuse/arc-saas"
-    },
-    "author": "Sourcefuse",
-    "license": "MIT",
-    "files": [
-        "README.md",
-        "dist",
-        "src",
-        "!*/__tests__"
-    ],
-    "dependencies": {
-        "@loopback/boot": "^8.0.4",
-        "@loopback/context": "^8.0.3",
-        "@loopback/core": "^7.0.3",
-        "@loopback/openapi-v3": "^11.0.4",
-        "@loopback/repository": "^8.0.3",
-        "@loopback/rest": "^15.0.4",
-        "@loopback/rest-explorer": "^8.0.4",
-        "@loopback/service-proxy": "^8.0.3",
-        "@opentelemetry/exporter-jaeger": "^1.15.0",
-        "@opentelemetry/plugin-dns": "^0.15.0",
-        "@opentelemetry/plugin-http": "^0.18.2",
-        "@opentelemetry/plugin-https": "^0.18.2",
-        "@opentelemetry/plugin-pg": "^0.15.0",
-        "@opentelemetry/plugin-pg-pool": "^0.15.0",
-        "@opentelemetry/sdk-trace-base": "^1.15.0",
-        "@opentelemetry/sdk-trace-node": "^1.15.0",
-        "@sourceloop/core": "^20.0.0",
-        "@sourceloop/feature-toggle-service": "^8.0.0",
-        "@types/jsonwebtoken": "^9.0.5",
-        "dotenv": "^16.4.5",
-        "dotenv-extended": "^2.9.0",
-        "loopback-connector-postgresql": "^7.1.8",
-        "loopback4-authentication": "^13.0.0",
-        "loopback4-authorization": "^8.0.0",
-        "loopback4-billing": "^2.0.0",
-        "swagger-stats": "^0.99.5",
-        "symlink-resolver": "0.2.1",
-        "tslib": "^2.6.2"
-    },
-    "optionalDependencies": {
-        "@loopback/sequelize": "^0.8.0",
-        "sequelize": "^6.37.7"
-    },
-    "devDependencies": {
-        "@istanbuljs/nyc-config-typescript": "^1.0.2",
-        "@loopback/build": "^12.0.3",
-        "@loopback/eslint-config": "^16.0.1",
-        "@loopback/testlab": "^8.0.3",
-        "@types/node": "^20.12.7",
-        "@types/sequelize": "^4.28.20",
-        "eslint": "^8.57.0",
-        "mochawesome": "^7.1.3",
-        "nodemon": "^2.0.21",
-        "nyc": "^15.1.0",
-        "source-map-support": "^0.5.21",
-        "typescript": "^5.4.5"
-    },
-    "publishConfig": {
-        "registry": "https://registry.npmjs.org/",
-        "access": "public"
-    },
-    "typedoc": {
-        "config": {
-            "entryPoints": [
-                "src/index.ts"
-            ],
-            "out": "services/subscription-service",
-            "plugin": [
-                "typedoc-plugin-markdown"
-            ]
-        }
+  "name": "@sourceloop/ctrl-plane-subscription-service",
+  "version": "0.5.0",
+  "description": "Subscription management microservice for SaaS control plane",
+  "keywords": [
+    "loopback-microservice",
+    "loopback",
+    "saas",
+    "subscription",
+    "subscription-management",
+    "subscription-service",
+    "control-plane",
+    "multi-tenant",
+    "multi-tenant-saas",
+    "multi-tenancy"
+  ],
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "engines": {
+    "node": ">=20"
+  },
+  "scripts": {
+    "build": "lb-tsc",
+    "build:watch": "lb-tsc --watch",
+    "lint": "npm run eslint && npm run prettier:check",
+    "lint:fix": "npm run eslint:fix && npm run prettier:fix",
+    "prettier:cli": "prettier \"**/*.ts\" \"**/*.js\"",
+    "prettier:check": "npm run prettier:cli -- -l",
+    "prettier:fix": "npm run prettier:cli -- --write",
+    "eslint": "eslint --report-unused-disable-directives .",
+    "eslint:fix": "npm run eslint -- --fix",
+    "pretest": "npm run rebuild",
+    "test": "lb-mocha --allow-console-logs \"dist/__tests__\"",
+    "test:dev": "lb-mocha --allow-console-logs dist/__tests__/**/*.js",
+    "docker:build": "DOCKER_BUILDKIT=1 sudo docker build --build-arg NR_ENABLED=$NR_ENABLED_VALUE --build-arg SERVICE_NAME=subscription-service --build-arg FROM_FOLDER=services  -t $IMAGE_REPO_NAME/$npm_package_name:$npm_package_version ../../. -f ./Dockerfile",
+    "docker:run": "docker run -p 3000:3000 -d subscription-service",
+    "symlink-resolver": "symlink-resolver",
+    "resolve-links": "npm run symlink-resolver build ./node_modules/@local",
+    "premigrate": "npm run build",
+    "migrate": "node ./dist/migrate",
+    "preopenapi-spec": "npm run build",
+    "openapi-spec": "node ./dist/openapi-spec",
+    "prestart": "npm run clean && npm run openapi-spec",
+    "start": "node -r ./dist/opentelemetry-registry.js -r source-map-support/register .",
+    "dev": "nodemon --watch src -e ts --exec \"npm run start\"",
+    "clean": "lb-clean dist *.tsbuildinfo .eslintcache",
+    "rebuild": "npm run clean && npm run build",
+    "docker:push": "sudo docker push $IMAGE_REPO_NAME/$npm_package_name:$npm_package_version",
+    "docker:build:dev": "DOCKER_BUILDKIT=1 sudo docker build --build-arg NR_ENABLED=$NR_ENABLED_VALUE -t $REPOSITORY_URI:$npm_package_name .",
+    "docker:push:dev": "docker push $REPOSITORY_URI:undefined",
+    "coverage": "nyc npm run test"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/sourcefuse/arc-saas"
+  },
+  "author": "Sourcefuse",
+  "license": "MIT",
+  "files": [
+    "README.md",
+    "dist",
+    "src",
+    "!*/__tests__"
+  ],
+  "dependencies": {
+    "@loopback/boot": "^8.0.4",
+    "@loopback/context": "^8.0.3",
+    "@loopback/core": "^7.0.3",
+    "@loopback/openapi-v3": "^11.0.4",
+    "@loopback/repository": "^8.0.3",
+    "@loopback/rest": "^15.0.4",
+    "@loopback/rest-explorer": "^8.0.4",
+    "@loopback/service-proxy": "^8.0.3",
+    "@opentelemetry/exporter-jaeger": "^1.15.0",
+    "@opentelemetry/plugin-dns": "^0.15.0",
+    "@opentelemetry/plugin-http": "^0.18.2",
+    "@opentelemetry/plugin-https": "^0.18.2",
+    "@opentelemetry/plugin-pg": "^0.15.0",
+    "@opentelemetry/plugin-pg-pool": "^0.15.0",
+    "@opentelemetry/sdk-trace-base": "^1.15.0",
+    "@opentelemetry/sdk-trace-node": "^1.15.0",
+    "@sourceloop/core": "^20.0.0",
+    "@sourceloop/feature-toggle-service": "^8.0.0",
+    "@types/jsonwebtoken": "^9.0.5",
+    "dotenv": "^16.4.5",
+    "dotenv-extended": "^2.9.0",
+    "loopback-connector-postgresql": "^7.1.8",
+    "loopback4-authentication": "^13.0.0",
+    "loopback4-authorization": "^8.0.0",
+    "loopback4-billing": "^2.0.0",
+    "swagger-stats": "^0.99.5",
+    "symlink-resolver": "0.2.1",
+    "tslib": "^2.6.2"
+  },
+  "optionalDependencies": {
+    "@loopback/sequelize": "^0.8.0",
+    "sequelize": "^6.37.7"
+  },
+  "devDependencies": {
+    "@istanbuljs/nyc-config-typescript": "^1.0.2",
+    "@loopback/build": "^12.0.3",
+    "@loopback/eslint-config": "^16.0.1",
+    "@loopback/testlab": "^8.0.3",
+    "@types/node": "^20.12.7",
+    "@types/sequelize": "^4.28.20",
+    "eslint": "^8.57.0",
+    "mochawesome": "^7.1.3",
+    "nodemon": "^2.0.21",
+    "nyc": "^15.1.0",
+    "source-map-support": "^0.5.21",
+    "typescript": "^5.4.5"
+  },
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/",
+    "access": "public",
+    "provenance": true
+  },
+  "typedoc": {
+    "config": {
+      "entryPoints": [
+        "src/index.ts"
+      ],
+      "out": "services/subscription-service",
+      "plugin": [
+        "typedoc-plugin-markdown"
+      ]
     }
+  }
 }

--- a/services/tenant-management-service/package.json
+++ b/services/tenant-management-service/package.json
@@ -136,7 +136,8 @@
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "typedoc": {
     "config": {


### PR DESCRIPTION
BREAKING CHANGE:
major bump all services

GH-00

1. Reverting the changelog file changes done in previous commit  #102 
2. changed the release yml file 
   - to bump major version - as lerna will not bump it to major for the very first time(will be removed later)
   - added id-token: write access for oidc trusted publishing
   - removed npm registry authentication
3. added provenance to all the packages

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Intermediate change (work in progress)

## Checklist:

- [ ] Performed a self-review of my own code
- [ ] npm test passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the style guide
- [ ] API Documentation in code was updated
- [ ] Any dependent changes have been merged and published in downstream modules
